### PR TITLE
C++17

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ using minimal = ::afsm::state_machine<minimal_def>;
 
 void use()
 {
-    mimimal fsm;
+    minimal fsm;
     fsm.process_event(start{});
     fsm.process_event(stop{});
 }

--- a/include/afsm/detail/transitions.hpp
+++ b/include/afsm/detail/transitions.hpp
@@ -424,19 +424,19 @@ public:
 
     state_transition_table(fsm_type& fsm, state_transition_table const& rhs)
         : fsm_{&fsm},
-          current_state_{(std::size_t)rhs.current_state_},
+          current_state_{static_cast<std::size_t>(rhs.current_state_)},
           states_{inner_states_constructor::copy_construct(fsm, rhs.states_)}
     {}
     state_transition_table(fsm_type& fsm, state_transition_table&& rhs)
         : fsm_{&fsm},
-          current_state_{(std::size_t)rhs.current_state_},
+          current_state_{static_cast<std::size_t>(rhs.current_state_)},
           states_{inner_states_constructor::move_construct(fsm, std::move(rhs.states_))}
     {}
 
     state_transition_table(state_transition_table const&) = delete;
     state_transition_table(state_transition_table&& rhs)
         : fsm_{rhs.fsm_},
-          current_state_{(std::size_t)rhs.current_state_},
+          current_state_{static_cast<std::size_t>(rhs.current_state_)},
           states_{std::move(rhs.states_)}
     {}
     state_transition_table&
@@ -490,7 +490,7 @@ public:
     std::size_t
     current_state() const
     {
-        return (std::size_t)current_state_;
+        return static_cast<std::size_t>(current_state_);
     }
 
     void


### PR DESCRIPTION
exchanged old-style casts with static-casts and found a typo in the Readme, preventing the given example to compile.